### PR TITLE
Minor installation fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@ add_subdirectory(libbruker)
 
 # Build the converter
 find_package(Ismrmrd REQUIRED)
-
+find_package(HDF5 REQUIRED)
 #set(Boost_NO_BOOST_CMAKE ON)
 
 if(WIN32)
@@ -17,14 +17,14 @@ if(WIN32)
 endif(WIN32)
 
 include_directories(
-  ${Boost_INCLUDE_DIR}	
+  ${Boost_INCLUDE_DIR} ${HDF5_INCLUDE_DIRS}
   ${ISMRMRD_INCLUDE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/libbruker
   )
 
 add_executable(bruker_to_ismrmrd main.cpp)
-target_link_libraries(bruker_to_ismrmrd bruker ${ISMRMRD_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(bruker_to_ismrmrd bruker ${ISMRMRD_LIBRARIES} ${Boost_LIBRARIES} ${HDF5_LIBRARIES})
 
 install(TARGETS bruker_to_ismrmrd DESTINATION bin COMPONENT main)
 

--- a/src/libbruker/brukerparameterparser.hpp
+++ b/src/libbruker/brukerparameterparser.hpp
@@ -22,6 +22,8 @@
 #include <fstream>
 #include <vector>
 #include <math.h>
+#include <climits>
+#include <cstdlib>
 
 enum {VARIABLE_START = 1,
       VIS_START,


### PR DESCRIPTION
Problem with resolving exit, atoi and atof was fixed by including cstdlib. Problem with resolving some data type limits was fixed by including climits. Problem with finding HDF5 headers and libs was fixed in src/CMakeLists.txt. 